### PR TITLE
fix: correct docs to view react examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Just navigate to the folder with your chosen example and open html file in the b
 ```
 npm i 
 ```
-* Run development mode
+* Run build
 ```
-npm run dev
+npm run build
 ```
-
-Now the app is accessible at ```localhost:3000```
+ 
+Now you will be able to see the react components in `index.html`. 
 
 # My Social Media
 The examples are posted here:


### PR DESCRIPTION
Running `npm run dev` fails:

<img width="386" alt="Screenshot 2024-03-09 at 15 54 56" src="https://github.com/atherosai/ui/assets/60209991/b925f87f-d599-4680-a866-59d20cb2f8a9">
