### PR TITLE
fix: remove scroll bar

### DIFF
--- a/toast-notification-01/style.css
+++ b/toast-notification-01/style.css
@@ -5,6 +5,7 @@
     --notification-background: #313e2c;
     --notification-primary: #aaec8a;
     --background: #0d110e;
+    --bottom-distance: 1.5rem;
 }
 
 * {
@@ -24,7 +25,7 @@ body {
     width: max-content;
     left: 0; 
     right: 0; 
-    bottom: 1.5rem;
+    bottom: var(--bottom-distance);
     margin-left: auto; 
     margin-right: auto; 
     border-radius: 0.375rem;
@@ -33,7 +34,7 @@ body {
     color: var(--notification-primary);
     box-shadow: 0 1px 10px 
         rgba(0, 0, 0, 0.1);
-    transform: translateY(1.875rem);
+    transform: translateY(var(--bottom-distance));
     opacity: 0;
     visibility: hidden;
     animation: fade-in 3s linear;


### PR DESCRIPTION
in `toast-notification-0`, if you wait until the toast bar is gone, you can see it creates a scroll bar in the  right side of the browser.
this is because there is `bottom: 1.5rem;`, but also `transform: translateY(1.875rem);`, which moves the .notification out of the view point, to fix this issue, the value of `translateY` shouldn't exceed `bottom`.
![image](https://github.com/user-attachments/assets/96e9c38f-045f-422f-8318-7c0f212b7368)
I use variable ` --bottom-distance: 1.5rem;` to unify the 2 values.